### PR TITLE
Add interactive language selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # codextest
+
+This repository contains a minimal Java web server example that listens on port **9099** and serves a small web page. The page lets you select a programming language and shows the typical file extension and a sample Fortify SCA command for that language.
+
+## Running the server
+
+1. Compile the Java source:
+
+   ```bash
+   javac src/Main.java
+   ```
+
+2. Run the server:
+
+   ```bash
+   java -cp src Main
+   ```
+
+   The server will start and print `Server running on http://localhost:9099`.
+
+3. Open your browser and navigate to `http://localhost:9099`. You will see a drop-down menu for choosing a language. Selecting one displays the file extension and an example Fortify command.
+
+## Scanning with Fortify SCA
+
+If you have Fortify SCA installed, you can analyze this project as follows:
+
+```bash
+sourceanalyzer -b codextest -clean
+sourceanalyzer -b codextest javac src/Main.java
+sourceanalyzer -b codextest -scan -f codextest.fpr
+```
+
+This will produce a Fortify Project Results (FPR) file named `codextest.fpr` that you can open with Fortify Audit Workbench.

--- a/src/Main.java
+++ b/src/Main.java
@@ -1,0 +1,55 @@
+import com.sun.net.httpserver.HttpServer;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpExchange;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        int port = 9099; // Port for the web server
+        HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);
+        server.createContext("/", new RootHandler());
+        server.setExecutor(null); // default executor
+        System.out.println("Server running on http://localhost:" + port);
+        server.start();
+    }
+
+    static class RootHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            String html = "<!DOCTYPE html>" +
+                    "<html><head><meta charset='UTF-8'><title>Fortify SCA Helper" +
+                    "</title></head><body>" +
+                    "<h1>Fortify SCA Language Helper</h1>" +
+                    "<label for='lang'>Choose language:</label>" +
+                    "<select id='lang'>" +
+                    "<option value=''>--Select--</option>" +
+                    "<option value='java'>Java</option>" +
+                    "<option value='python'>Python</option>" +
+                    "<option value='javascript'>JavaScript</option>" +
+                    "<option value='csharp'>C#</option>" +
+                    "</select>" +
+                    "<pre id='info'></pre>" +
+                    "<script>" +
+                    "const info=document.getElementById('info');" +
+                    "document.getElementById('lang').addEventListener('change',function(){" +
+                    "let data={};switch(this.value){" +
+                    "case 'java':data.ext='.java';data.cmd='sourceanalyzer -b myproj javac *.java';break;" +
+                    "case 'python':data.ext='.py';data.cmd='sourceanalyzer -b myproj python *.py';break;" +
+                    "case 'javascript':data.ext='.js';data.cmd='sourceanalyzer -b myproj node *.js';break;" +
+                    "case 'csharp':data.ext='.cs';data.cmd='sourceanalyzer -b myproj csc *.cs';break;" +
+                    "default:info.textContent='';return;}" +
+                    "info.textContent='Target extension: '+data.ext+'\nFortify command: '+data.cmd;" +
+                    "});" +
+                    "</script></body></html>";
+            byte[] response = html.getBytes("UTF-8");
+            exchange.getResponseHeaders().set("Content-Type", "text/html; charset=UTF-8");
+            exchange.sendResponseHeaders(200, response.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(response);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- serve a web page with a language dropdown
- display Fortify SCA example commands per language
- document the new page in README

## Testing
- `javac src/Main.java`


------
https://chatgpt.com/codex/tasks/task_e_683ff7cc340c8327a5199ddc8149b5aa